### PR TITLE
Windows Live Authentication bug

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -119,8 +119,10 @@ class auth_plugin_googleoauth2 extends auth_plugin_base {
             require_once($CFG->libdir . '/filelib.php');
             if ($authprovider == 'messenger') { //Windows Live returns an "Object moved" error with curl->post() encoding
                 $curl = new curl();
-                $postreturnvalues = $curl->get('https://oauth.live.com/token?client_id='.$params['client_id'].'&redirect_uri='.$params['redirect_uri'].'&client_secret='.$params['client_secret'].'&code='.$params['code'].'&grant_type=authorization_code');
-            } else {
+                //$postreturnvalues = $curl->get('https://oauth.live.com/token?client_id='.$params['client_id'].'&redirect_uri='.$params['redirect_uri'].'&client_secret='.$params['client_secret'].'&code='.$params['code'].'&grant_type=authorization_code');
+                $postreturnvalues = $curl->get('https://oauth.live.com/token?client_id=' . urlencode($params['client_id']) . '&redirect_uri=' . urlencode($params['redirect_uri'] ). '&client_secret=' . urlencode($params['client_secret']) . '&code=' .urlencode( $params['code']) . '&grant_type=authorization_code');
+
+           } else {
                 $curl = new curl();
                 $postreturnvalues = $curl->post($requestaccesstokenurl, $params);
             }


### PR DESCRIPTION
Dear developers,

I found an error when using auth_googleoauth2 plugin. I'm using Firefox 5 but the issue also occurs with IE8 and Chrome (I have not tried with others)
.
When I select Windows Live login method the following error message is shown:

The authentication provider sent us a communication error. Please try to sign-in again.
Más información sobre este error

If I click "more information about this error" link (http://docs.moodle.org/20/en/error/auth_googleoauth2/couldnotgetgoogleaccesstoken), I obtain:

error/auth googleoauth2/couldnotgetgoogleaccesstoken
There is currently no text in this page. You can search for this page title in other pages, or search the related logs.

Surfing in the code, I found the error is at auth.php line #122 and surfing a little more deeper I found the problem is that "curl_exec" returns:
Resource id #64{"error":"invalid_grant","error_description":"The provided value for the input parameter 'client_secret' is not valid."}

But I'm pretty sure my client secret is correct (I debug it), but If I change the mentioned line (auth.php #122) from:

$postreturnvalues = $curl->get('https://oauth.live.com/token?client_id='.$params['client_id'].'&redirect_uri='.$params['redirect_uri'].'&client_secret='.$params['client_secret'].'&code='.$params['code'].'&grant_type=authorization_code');

to:

$postreturnvalues = $curl->get('https://oauth.live.com/token?client_id=' . urlencode($params['client_id']) . '&redirect_uri=' . urlencode($params['redirect_uri'] ). '&client_secret=' . urlencode($params['client_secret']) . '&code=' .urlencode( $params['code']) . '&grant_type=authorization_code');

i.e. adding urlencode before each param, the problem is solved.

I don't understand why for you and your example (https://www.socialfutsal.com/futsal/login/) the plugin works and not for me and I don't know if other people is experiencing the same problem, but I think this is a good solution.

Update: This bug occurs because my secret key contains the character "+" and this is a special character for urls.

Best regards, Silvia Bastos.
