### PR TITLE
Support $CFG->alternateloginurl

### DIFF
--- a/README
+++ b/README
@@ -75,7 +75,7 @@ http://social.msdn.microsoft.com/Forums/en-US/messengerconnect/thread/515d546d-1
             <?php if (!empty($authprovider)) { ?>
             <br/><br/>
             <div class="moreproviderlink">
-                <a href='<?php echo $CFG->wwwroot . '/login/index.php?allauthproviders=true'; ?>' onclick="changecss('singinprovider','display','inline-block');"><?php echo get_string('moreproviderlink', 'auth_googleoauth2');?></a>    
+                <a href='<?php echo $CFG->wwwroot . (isset($CFG->alternateloginurl) ? $CFG->alternateloginurl : '/login/index.php') . '?allauthproviders=true'; ?>' onclick="changecss('singinprovider','display','inline-block');"><?php echo get_string('moreproviderlink', 'auth_googleoauth2');?></a>
             </div>
             <?php } ?>
         </center>

--- a/facebook_redirect.php
+++ b/facebook_redirect.php
@@ -11,6 +11,10 @@ if (empty($code)) {
     throw new moodle_exception('facebook_failure');
 }
 
-$url = new moodle_url('/login/index.php', array('code' => $code, 'authprovider' => 'facebook'));
+$loginurl = '/login/index.php';
+if (isset($CFG->alternateloginurl)) {
+    $loginurl = $CFG->alternateloginurl;
+}
+$url = new moodle_url($loginurl, array('code' => $code, 'authprovider' => 'facebook'));
 redirect($url);
 ?>

--- a/google_redirect.php
+++ b/google_redirect.php
@@ -11,6 +11,10 @@ if (empty($code)) {
     throw new moodle_exception('google_failure');
 }
 
-$url = new moodle_url('/login/index.php', array('code' => $code, 'authprovider' => 'google'));
+$loginurl = '/login/index.php';
+if (isset($CFG->alternateloginurl)) {
+    $loginurl = $CFG->alternateloginurl;
+}
+$url = new moodle_url($loginurl, array('code' => $code, 'authprovider' => 'google'));
 redirect($url);
 ?>

--- a/messenger_redirect.php
+++ b/messenger_redirect.php
@@ -11,6 +11,10 @@ if (empty($code)) {
     throw new moodle_exception('messenger_failure');
 }
 
-$url = new moodle_url('/login/index.php', array('code' => $code, 'authprovider' => 'messenger'));
+$loginurl = '/login/index.php';
+if (isset($CFG->alternateloginurl)) {
+    $loginurl = $CFG->alternateloginurl;
+}
+$url = new moodle_url($loginurl, array('code' => $code, 'authprovider' => 'messenger'));
 redirect($url);
 ?>


### PR DESCRIPTION
Moodle (not sure which version this was introduced in) has a 'alternateloginurl' config parameter that may be used to move login logic to an alternate place. Before this commit, the login url was always hardcoded as '/login/index.php'
