### PR TITLE
Added compatibility with core moodle setting

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -55,11 +55,7 @@ class auth_plugin_googleoauth2 extends auth_plugin_base {
             'mnethostid' => $CFG->mnet_localhost_id));
 
         //username must exist and have the right authentication method
-        if (!empty($user) && ($user->auth == 'googleoauth2')) {
-            return true;
-        }
-
-        return false;
+        return !empty($user) && $user->auth == 'googleoauth2';
     }
 
     /**
@@ -217,6 +213,10 @@ class auth_plugin_googleoauth2 extends auth_plugin_base {
 
                 //create the user if it doesn't exist
                 if (empty($user)) {
+
+                    // deny login if setting "Prevent account creation when authenticating" is on
+                    if($CFG->authpreventaccountcreation) throw new moodle_exception("noaccountyet", "auth_googleoauth2");
+
 
                     //get following incremented username
                     $lastusernumber = get_config('auth/googleoauth2', 'lastusernumber');

--- a/lang/en/auth_googleoauth2.php
+++ b/lang/en/auth_googleoauth2.php
@@ -48,3 +48,4 @@ $string['couldnotgetgoogleaccesstoken'] = 'The authentication provider sent us a
 $string['emailaddressmustbeverified'] = 'Your email address is not verified by the authentication method you selected. You likely have forgotten to click on a "verify email address" link that Google or Facebook should have sent you during your subscribtion to their service.';
 $string['moreproviderlink'] = 'Sign-in with another service.';
 $string['signinwithanaccount'] = 'Log in with:';
+$string['noaccountyet'] = 'You do not have permission to use the site yet. Please contact your administrator and ask them to activate your account.';


### PR DESCRIPTION
The setting can be found at this moodle url:

/moodle/admin/settings.php?section=manageauths

Or, Site Administration > Plugins > Authentication > Manage Authentication

The name of the setting is "Prevent account creation when authenticating," and the codename for it is "authpreventaccountcreation."

What are your thoughts?
