### PR TITLE
Fixed empty firstname and lastname

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -312,6 +312,7 @@ class auth_plugin_googleoauth2 extends auth_plugin_base {
                     if (!empty($newuser)) {
                         $newuser->id = $user->id;
                         $DB->update_record('user', $newuser);
+                        $user = (object) array_merge((array) $user, (array) $newuser);
                     }
 
                     complete_user_login($user);


### PR DESCRIPTION
Without this fix firstname and lastname are getting filled only after
user logs out and logs in again. Themes that welcome user like "Hello
Dmitry …" get confused and say just "Hello …"
