### PR TITLE
correct null country error for linkedin

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -323,8 +323,12 @@ class auth_plugin_googleoauth2 extends auth_plugin_base {
                         case 'linkedin':
                             $newuser->firstname =  $linkedinuser->firstName;
                             $newuser->lastname =  $linkedinuser->lastName;
-                            $newuser->country = $linkedinuser->country->code;
-                            $newuser->city = $linkedinuser->name;
+                            if (!empty($linkedinuser->location->country->code)) {
+                                $newuser->country = $linkedinuser->location->country->code;
+                            }
+                            if (!empty($linkedinuser->location->name)) {
+                                $newuser->city = $linkedinuser->location->name;
+                            }
                             break;
 
                         default:


### PR DESCRIPTION
The previous commit invoke $linkedinuser->country->code instead of $linkedinuser->location->country->code, generating a null value if no googleipinfodbkey is configured.
The database column "country" is not null, then the update operation will fail, resulting in inconsistent user info.
Here I correct the source of informations and only set value if is not empty.
