### PR TITLE
Do not show the login button if one of the Google settings (app key or secret) are empty

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -88,7 +88,7 @@ function auth_googleoauth2_render_buttons() {
 	$html .= "<center>";
 	$html .= "<div style=\"width:'1%'\">";
     $providerscount = 0;
-    $providerisenabled = get_config('auth/googleoauth2', 'googleclientid');
+    $providerisenabled = get_config('auth/googleoauth2', 'googleclientid') && get_config('auth/googleoauth2', 'googleclientsecret');
     $providerscount = $providerisenabled?$providerscount+1:$providerscount;
 	$displayprovider = ((empty($authprovider) || $authprovider == 'google' || $allauthproviders) && $providerisenabled);
 	$providerdisplaystyle = $displayprovider?'display:inline-block;padding:10px;':'display:none;';


### PR DESCRIPTION
Related to issue #81 
