### PR TITLE
Alligned version number with version on moodle.org

### DIFF
--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version  = 2016061202;
+$plugin->version  = 2016061204;
 $plugin->requires = 2014051200;   // Requires Moodle 2.7 or later.
 $plugin->release = '2.3 (Build: 2016061202)';
 $plugin->maturity = MATURITY_STABLE;             // This version's maturity level.


### PR DESCRIPTION
I experienced the following problem:
1. In my moodle install, I checked for available plugin updates
2. Regarding the Oauth plugin, the system tells me: "There is a new version 2016061204 available! Release 2.3 (Build: 2016061204)" 
3. I let moodle install the update (which is taken from moodle.org)
4. After successful installation, I do step one again and still see for the Oauth plugin:  "There is a new version 2016061204 available! Release 2.3 (Build: 2016061204)" 
5. I check the version number in the version.php file and see that the version of the plugin is: 2016061202 

Therefore I have changed the version to 2016061204
